### PR TITLE
Add example and checks for find_patches_line

### DIFF
--- a/examples/dispatch_io/find_patches_line.ipynb
+++ b/examples/dispatch_io/find_patches_line.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12345678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "include(\"../../src/Yggdrasil.jl\")\n",
+    "using .Yggdrasil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23456789",
+   "metadata": {},
+   "source": [
+    "# Find patches intersected by a line\n",
+    "This example shows how to use `find_patches_line` to locate patches that intersect a line segment." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34567890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_folder = \"../example_data/test_01/\"\n",
+    "snap = 105\n",
+    "Snapshot_meta = read_snapshot(data_folder, snap)\n",
+    "start_point = [0.0, 0.0, 0.0]\n",
+    "end_point = [1.0, 1.0, 1.0]\n",
+    "patches = find_patches_line(Snapshot_meta, start_point, end_point)\n",
+    "println(\"Found \" * string(length(patches)) * \" patches\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.11.5",
+   "language": "julia",
+   "name": "julia-1.11"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dispatch_io/FindPatchesLine.jl
+++ b/src/dispatch_io/FindPatchesLine.jl
@@ -51,6 +51,8 @@ function find_patches_line(
     start_point::AbstractVector{<:AbstractFloat},
     end_point::AbstractVector{<:AbstractFloat},
 )
+    @assert length(start_point) == 3 "start_point must have 3 values (x, y, z)"
+    @assert length(end_point) == 3 "end_point must have 3 values (x, y, z)"
     patches = Patch_NML[]
     for patch in Snapshot_meta.PATCHES
         if line_intersects_patch(start_point, end_point, patch)
@@ -71,6 +73,8 @@ function find_patches_line(
     end_point::AbstractVector{<:AbstractFloat},
     level::Int,
 )
+    @assert length(start_point) == 3 "start_point must have 3 values (x, y, z)"
+    @assert length(end_point) == 3 "end_point must have 3 values (x, y, z)"
     patches = Patch_NML[]
     for patch in Snapshot_meta.PATCHES
         if patch.LEVEL == level && line_intersects_patch(start_point, end_point, patch)


### PR DESCRIPTION
## Summary
- add input assertions to `find_patches_line`
- provide a simple notebook demonstrating `find_patches_line`

## Testing
- `julia --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821b6940cc832680bd576c44fc10d1